### PR TITLE
Aysnc features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stunk",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Stunk is a lightweight, framework-agnostic state management library for JavaScript and TypeScript. It uses chunk-based state units for efficient updates, reactivity, and performance optimization in React, Vue, Svelte, and Vanilla JS/TS applications.",
   "scripts": {
     "build": "tsup",

--- a/src/core/asyncChunk.ts
+++ b/src/core/asyncChunk.ts
@@ -289,7 +289,7 @@ export function asyncChunk<T, E extends Error = Error, P extends Record<string, 
     setParams: (params: Partial<P>) => {
       currentParams = { ...currentParams, ...params };
       if (enabled) {
-        fetchData();
+        fetchData(params, retryCount, true); // Fetch immediately with new params
       }
     },
   };

--- a/src/use-react/hooks/useAsyncChunk.ts
+++ b/src/use-react/hooks/useAsyncChunk.ts
@@ -60,6 +60,26 @@ export interface UseAsyncChunkOptions<P extends Record<string, any> = {}> {
 }
 
 export function useAsyncChunk<T, E extends Error = Error, P extends Record<string, any> = {}>(
+  asyncChunk: PaginatedAsyncChunk<T, E> & { setParams: (params: Partial<P>) => void },
+  options?: UseAsyncChunkOptions<P> | Partial<P>
+): UseAsyncChunkResultWithParamsAndPagination<T, E, P>;
+
+export function useAsyncChunk<T, E extends Error = Error, P extends Record<string, any> = {}>(
+  asyncChunk: PaginatedAsyncChunk<T, E>,
+  options?: UseAsyncChunkOptions<P> | Partial<P>
+): UseAsyncChunkResultWithPagination<T, E, P>;
+
+export function useAsyncChunk<T, E extends Error = Error, P extends Record<string, any> = {}>(
+  asyncChunk: AsyncChunk<T, E> & { setParams: (params: Partial<P>) => void },
+  options?: UseAsyncChunkOptions<P> | Partial<P>
+): UseAsyncChunkResultWithParams<T, E, P>;
+
+export function useAsyncChunk<T, E extends Error = Error, P extends Record<string, any> = {}>(
+  asyncChunk: AsyncChunk<T, E>,
+  options?: UseAsyncChunkOptions<P> | Partial<P>
+): UseAsyncChunkResult<T, E, P>;
+
+export function useAsyncChunk<T, E extends Error = Error, P extends Record<string, any> = {}>(
   asyncChunk: AsyncChunk<T, E> | PaginatedAsyncChunk<T, E> | (AsyncChunk<T, E> & { setParams: (params: Partial<P>) => void }),
   options?: UseAsyncChunkOptions<P> | Partial<P> // Support both formats for backward compatibility
 ) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -198,7 +198,7 @@ export function shallowEqual<T>(a: T, b: T): boolean {
   return false;
 }
 
-export function validateObjectShape<T>(original: T, updated: T, path = ''): void {
+export function validateObjectShape<T>(original: T, updated: T, path = '') {
   if (typeof original === 'object' && original !== null && typeof updated === 'object' && updated !== null) {
     if (Array.isArray(original) && Array.isArray(updated)) {
       if (original.length > 0 && typeof original[0] === 'object') {


### PR DESCRIPTION
Async Chunk to paginate properly.
infinite query example is also included


Note the following when using `asyncChunk `and `useAsyncChunk ` hook with pagination.

- You need to explicitly define  `initialParams: { page: 1, pageSize: 10 }` prop
- You can pass default params to asyncChunk like so

```
 export const paginatedUsersChunk = asyncChunk(
  async (params: PaginatedUsersParams = { page: 1, pageSize: 10 }) => {
    // Fetcher now has defaults
  }
 );
```
or pass it in the hook like so

```
const { data, loading, error, reload, setParams } = useAsyncChunk(
    paginatedUsersChunk,
    {
      initialParams: { page: 1, pageSize: 10 }, 
      // Initial page and page size - 
     //  This is intentional, because we want you to be specific about it...
    }
  );
```

- Better to transform the data in asyncChunk:  So you can just grab it from the data prop in the hook
  
 ```
 ...
 return {
      users,
      currentPage: json.info.page,
      pageSize,
      totalPages,
      totalUsers: simulatedTotalUsers,
      hasNextPage: json.info.page < totalPages,
      hasPrevPage: json.info.page > 1,
    };
```
  
```
  // Extract current values from data
  const currentPage = data?.currentPage || 1;
  const currentPageSize = data?.pageSize || 5;
```

- You can use actions like so

 ```
const handlePageChange = (newPage: number) => {
    setParams({ page: newPage, pageSize: currentPageSize });
  };

  const handlePageSizeChange = (newPageSize: number) => {
    setParams({ page: 1, pageSize: newPageSize });
  };

  const handleRefresh = () => {
    reload();
  };
```

Enjoy!



 