### PR TITLE
feat(vue): Vue 3 composables port for v3 (stunk/vue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/use-react/index.d.ts",
       "import": "./dist/use-react/index.js"
     },
+    "./vue": {
+      "types": "./dist/use-vue/index.d.ts",
+      "import": "./dist/use-vue/index.js"
+    },
     "./package.json": "./package.json"
   },
   "keywords": [

--- a/src/query/async-chunk.ts
+++ b/src/query/async-chunk.ts
@@ -280,6 +280,19 @@ function createAsyncChunkInternal<T, E extends Error = Error, P extends Record<s
     }
   };
 
+  // Paginated chunks include the target page (or cursor) in the key —
+  // params alone would make a nextPage() fetch dedup onto the previous
+  // page's still-registered request and silently skip the new page.
+  const buildDedupKey = () => {
+    const paramsKey = JSON.stringify(currentParams);
+    if (!isPaginated) return `${chunkKey}:${paramsKey}`;
+    const pagination = baseChunk.get().pagination;
+    const pageKey = isCursorMode
+      ? `cursor=${pagination?.cursor ?? ''}`
+      : `page=${pagination?.page ?? 1}`;
+    return `${chunkKey}:${paramsKey}:${pageKey}`;
+  };
+
   const fetchData = async (params?: Partial<P>, retries = retryCount, force = false): Promise<void> => {
     if (!isEnabled()) return;
 
@@ -290,7 +303,7 @@ function createAsyncChunkInternal<T, E extends Error = Error, P extends Record<s
     if (!force && !isStale() && baseChunk.get().data !== null) return;
 
     const paramsKeyAtStart = JSON.stringify(currentParams);
-    const dedupKey = `${chunkKey}:${paramsKeyAtStart}`;
+    const dedupKey = buildDedupKey();
 
     if (inFlightRequests.has(dedupKey)) {
       return inFlightRequests.get(dedupKey)!;
@@ -298,6 +311,13 @@ function createAsyncChunkInternal<T, E extends Error = Error, P extends Record<s
 
     const state = baseChunk.get();
     const previousData = state.data;
+
+    // Capture at request start — nextPage() resets the flag after its await,
+    // which races with a subsequent nextPage() issued from a microtask (e.g.
+    // a framework scheduler reacting to this fetch landing). Reading the
+    // closure flag at resolve time would see false and replace instead of
+    // accumulate.
+    const isNextPageRequest = isNextPageFetch;
 
     baseChunk.set({
       ...state,
@@ -358,7 +378,7 @@ function createAsyncChunkInternal<T, E extends Error = Error, P extends Record<s
         if (
           isPaginated &&
           paginationMode === 'accumulate' &&
-          isNextPageFetch &&
+          isNextPageRequest &&
           previousData &&
           Array.isArray(previousData) &&
           Array.isArray(data)
@@ -451,8 +471,7 @@ function createAsyncChunkInternal<T, E extends Error = Error, P extends Record<s
 
     cancel: () => {
       isCancelled = true;
-      const dedupKey = `${chunkKey}:${JSON.stringify(currentParams)}`;
-      inFlightRequests.delete(dedupKey);
+      inFlightRequests.delete(buildDedupKey());
       const state = baseChunk.get();
       if (state.loading) {
         baseChunk.set({ ...state, loading: false });

--- a/src/use-vue/composables/use-async-chunk.ts
+++ b/src/use-vue/composables/use-async-chunk.ts
@@ -1,0 +1,296 @@
+import {
+  shallowReactive,
+  toRefs,
+  toValue,
+  watch,
+  getCurrentScope,
+  onScopeDispose,
+  type Ref,
+  type MaybeRefOrGetter,
+} from "vue";
+import {
+  AsyncChunk,
+  AsyncStateWithPagination,
+  PaginatedAsyncChunk,
+  PaginationState,
+} from "../../query/async-chunk";
+
+// Type guard to check if chunk has pagination methods
+function isPaginatedChunk<T, E extends Error>(
+  c: AsyncChunk<T, E> | PaginatedAsyncChunk<T, E>
+): c is PaginatedAsyncChunk<T, E> {
+  return 'nextPage' in c;
+}
+
+function hasSetParams<T, E extends Error, P extends Record<string, any>>(
+  c: AsyncChunk<T, E> | (AsyncChunk<T, E> & { setParams: (params: Partial<P>) => void })
+): c is AsyncChunk<T, E> & { setParams: (params: Partial<P>) => void } {
+  return 'setParams' in c;
+}
+
+function hasClearParams<T, E extends Error>(
+  c: AsyncChunk<T, E>
+): c is AsyncChunk<T, E> & { clearParams: () => void } {
+  return 'clearParams' in c;
+}
+
+function hasScopedFactory<T, E extends Error>(
+  c: AsyncChunk<T, E> | PaginatedAsyncChunk<T, E>
+): c is (AsyncChunk<T, E> | PaginatedAsyncChunk<T, E>) & {
+  __scopedFactory: () => AsyncChunk<T, E> | PaginatedAsyncChunk<T, E>;
+} {
+  return '__scopedFactory' in c;
+}
+
+export interface UseAsyncChunkResult<T, E extends Error, P extends Record<string, any>> {
+  data: Readonly<Ref<T | null>>;
+  loading: Readonly<Ref<boolean>>;
+  error: Readonly<Ref<E | null>>;
+  lastFetched: Readonly<Ref<number | undefined>>;
+  isPlaceholderData: Readonly<Ref<boolean>>;
+  reload: (params?: Partial<P>) => Promise<void>;
+  refresh: (params?: Partial<P>) => Promise<void>;
+  mutate: (mutator: (currentData: T | null) => T | null) => void;
+  reset: (refetch?: boolean) => void;
+}
+
+export interface UseAsyncChunkResultWithParams<T, E extends Error, P extends Record<string, any>>
+  extends UseAsyncChunkResult<T, E, P> {
+  setParams: (params: Partial<Record<keyof P, P[keyof P] | null>>) => void;
+  clearParams: () => void;
+}
+
+export interface UseAsyncChunkResultWithPagination<T, E extends Error, P extends Record<string, any>>
+  extends UseAsyncChunkResult<T, E, P> {
+  pagination: Readonly<Ref<PaginationState | undefined>>;
+  nextPage: () => Promise<void>;
+  prevPage: () => Promise<void>;
+  goToPage: (page: number) => Promise<void>;
+  resetPagination: () => Promise<void>;
+}
+
+export interface UseAsyncChunkResultWithParamsAndPagination<T, E extends Error, P extends Record<string, any>>
+  extends UseAsyncChunkResultWithParams<T, E, P>,
+  Omit<UseAsyncChunkResultWithPagination<T, E, P>, keyof UseAsyncChunkResult<T, E, P>> { }
+
+export interface UseAsyncChunkOptions<T = any, E extends Error = Error, P extends Record<string, any> = {}> {
+  /**
+   * Parameters to pass to the fetcher. Accepts a plain object, a ref, or a
+   * getter — when the resolved value changes, the chunk automatically
+   * re-fetches with the new values.
+   */
+  params?: MaybeRefOrGetter<Partial<P> | undefined>;
+  /**
+   * Force a fetch on mount even when the chunk has no params.
+   * Ignored if params is provided.
+   * (default: false)
+   */
+  fetchOnMount?: boolean;
+  /**
+   * Whether the chunk is enabled. Accepts a plain boolean, a ref, or a
+   * getter — flipping to true triggers a fetch, flipping to false cancels
+   * any in-flight request.
+   * If false, the chunk will not fetch data.
+   * (default: true)
+   */
+  enabled?: MaybeRefOrGetter<boolean>;
+  /**
+   * Called after every successful fetch at the composable level.
+   * Has full access to component context — safe to call router.push(), etc.
+   */
+  onSuccess?: (data: T) => void;
+  /**
+   * Called when a fetch fails at the composable level.
+   * Has full access to component context — safe to call router.push(), etc.
+   */
+  onError?: (error: E) => void;
+}
+
+// Overloads
+export function useAsyncChunk<T, E extends Error = Error, P extends Record<string, any> = {}>(
+  asyncChunk: PaginatedAsyncChunk<T, E> & { setParams: (params: Partial<P>) => void },
+  options?: UseAsyncChunkOptions<T, E, P>
+): UseAsyncChunkResultWithParamsAndPagination<T, E, P>;
+
+export function useAsyncChunk<T, E extends Error = Error, P extends Record<string, any> = {}>(
+  asyncChunk: PaginatedAsyncChunk<T, E>,
+  options?: UseAsyncChunkOptions<T, E, P>
+): UseAsyncChunkResultWithPagination<T, E, P>;
+
+export function useAsyncChunk<T, E extends Error = Error, P extends Record<string, any> = {}>(
+  asyncChunk: AsyncChunk<T, E> & { setParams: (params: Partial<P>) => void },
+  options?: UseAsyncChunkOptions<T, E, P>
+): UseAsyncChunkResultWithParams<T, E, P>;
+
+export function useAsyncChunk<T, E extends Error = Error, P extends Record<string, any> = {}>(
+  asyncChunk: AsyncChunk<T, E>,
+  options?: UseAsyncChunkOptions<T, E, P>
+): UseAsyncChunkResult<T, E, P>;
+
+/**
+ * Subscribes to an async chunk and returns its state as reactive refs along
+ * with reload, refresh, mutate, and reset. Chunks created with params expose
+ * setParams/clearParams; paginated chunks expose the pagination methods.
+ *
+ * State is held in a single `shallowReactive` object and exposed via `toRefs`,
+ * so every returned ref stays in sync with the chunk while remaining
+ * individually consumable in templates.
+ *
+ * @example
+ * const { data, loading, error, reload } = useAsyncChunk(userChunk);
+ *
+ * @example
+ * // Reactive params — refetches when the ref changes
+ * const search = ref('');
+ * const { data } = useAsyncChunk(postsChunk, { params: () => ({ search: search.value }) });
+ */
+export function useAsyncChunk<T, E extends Error = Error, P extends Record<string, any> = {}>(
+  asyncChunkArg: AsyncChunk<T, E> | PaginatedAsyncChunk<T, E>,
+  options: UseAsyncChunkOptions<T, E, P> = {}
+) {
+  // Resolve to a per-component instance if this chunk opted into scoping —
+  // completely invisible to the caller, same chunk reference passed in either way.
+  // Composables run once per component setup, so no memoization is needed.
+  const asyncChunk = hasScopedFactory(asyncChunkArg)
+    ? asyncChunkArg.__scopedFactory()
+    : asyncChunkArg;
+
+  const { fetchOnMount = false, onSuccess, onError } = options;
+
+  const isEnabled = () => toValue(options.enabled) ?? true;
+  const currentParams = () => toValue(options.params);
+
+  const initialState = asyncChunk.get();
+
+  // Single reactive state object per review feedback — exposed via toRefs.
+  // Optional keys are seeded explicitly so toRefs creates a ref for each.
+  const state = shallowReactive<{
+    data: T | null;
+    loading: boolean;
+    error: E | null;
+    lastFetched: number | undefined;
+    isPlaceholderData: boolean;
+    pagination: PaginationState | undefined;
+  }>({
+    data: initialState.data,
+    loading: initialState.loading,
+    error: initialState.error,
+    lastFetched: initialState.lastFetched,
+    isPlaceholderData: initialState.isPlaceholderData ?? false,
+    pagination: initialState.pagination,
+  });
+
+  // Assign keys explicitly — newState may omit optional keys, and a bare
+  // Object.assign would leave stale values behind.
+  const syncState = (newState: AsyncStateWithPagination<T, E>) => {
+    state.data = newState.data;
+    state.loading = newState.loading;
+    state.error = newState.error;
+    state.lastFetched = newState.lastFetched;
+    state.isPlaceholderData = newState.isPlaceholderData ?? false;
+    state.pagination = newState.pagination;
+  };
+
+  let prevState = initialState;
+
+  const unsubscribe = asyncChunk.subscribe((newState) => {
+    if (prevState.loading && !newState.loading && !newState.error && newState.data !== null) {
+      onSuccess?.(newState.data as T);
+    }
+
+    if (prevState.loading && !newState.loading && newState.error) {
+      onError?.(newState.error as E);
+    }
+
+    prevState = newState;
+    syncState(newState);
+  });
+
+  const fetchWithParams = (params: Partial<P> | undefined) => {
+    if (params && hasSetParams(asyncChunk)) {
+      asyncChunk.setParams(params);
+    } else {
+      asyncChunk.reload();
+    }
+  };
+
+  // Initial fetch — same semantics as the react hook's mount effect
+  const params = currentParams();
+  if (params && hasSetParams(asyncChunk)) {
+    if (isEnabled()) asyncChunk.setParams(params);
+  } else if (isEnabled() && (fetchOnMount || (initialState.data === null && !initialState.loading))) {
+    asyncChunk.reload();
+  }
+
+  // One watcher covers both enabled flips and param changes — when they land
+  // together, the enabled branch fetches with the fresh params, so there is
+  // no duplicate fetch to guard against.
+  watch(
+    [isEnabled, () => {
+      const p = currentParams();
+      return p ? JSON.stringify(p) : null;
+    }],
+    ([enabled, paramsKey], [wasEnabled, prevParamsKey]) => {
+      if (!wasEnabled && enabled) {
+        // enabled flipped true — fetch with current params
+        fetchWithParams(currentParams());
+        return;
+      }
+
+      if (wasEnabled && !enabled) {
+        // enabled flipped false — cancel in-flight + clear loading
+        (asyncChunk as any).cancel?.();
+        return;
+      }
+
+      if (enabled && paramsKey !== prevParamsKey) {
+        const freshParams = currentParams();
+        if (freshParams && hasSetParams(asyncChunk)) {
+          asyncChunk.setParams(freshParams);
+        }
+      }
+    }
+  );
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      unsubscribe();
+      asyncChunk.cleanup();
+    });
+  }
+
+  const {
+    data, loading, error, lastFetched, isPlaceholderData, pagination,
+  } = toRefs(state);
+
+  const result: UseAsyncChunkResult<T, E, P> = {
+    data,
+    loading,
+    error,
+    lastFetched,
+    isPlaceholderData,
+    reload: (params?: Partial<P>) => asyncChunk.reload(params),
+    refresh: (params?: Partial<P>) => asyncChunk.refresh(params),
+    mutate: (mutator: (currentData: T | null) => T | null) => asyncChunk.mutate(mutator),
+    reset: (refetch?: boolean) => asyncChunk.reset(refetch),
+  };
+
+  if (hasSetParams(asyncChunk)) {
+    const withParams = result as UseAsyncChunkResultWithParams<T, E, P>;
+    withParams.setParams = (params) => asyncChunk.setParams(params);
+    withParams.clearParams = () => {
+      if (hasClearParams(asyncChunk)) asyncChunk.clearParams();
+    };
+  }
+
+  if (isPaginatedChunk(asyncChunk)) {
+    const paginatedResult = result as UseAsyncChunkResultWithPagination<T, E, P>;
+    paginatedResult.pagination = pagination;
+    paginatedResult.nextPage = () => asyncChunk.nextPage();
+    paginatedResult.prevPage = () => asyncChunk.prevPage();
+    paginatedResult.goToPage = (page: number) => asyncChunk.goToPage(page);
+    paginatedResult.resetPagination = () => asyncChunk.resetPagination();
+  }
+
+  return result;
+}

--- a/src/use-vue/composables/use-chunk-value.ts
+++ b/src/use-vue/composables/use-chunk-value.ts
@@ -1,10 +1,10 @@
-import type { Ref } from "vue";
+import type { ComputedRef } from "vue";
 import { useChunk } from "./use-chunk";
 import type { Chunk, ReadOnlyChunk } from "../../core/core";
 
 /**
- * Subscribes to a chunk and returns only its current value as a readonly ref.
- * Accepts both writable `Chunk<T>` and read-only `ReadOnlyChunk<T>`
+ * Subscribes to a chunk and returns only its current value as a read-only
+ * `computed`. Accepts both writable `Chunk<T>` and read-only `ReadOnlyChunk<T>`
  * (e.g. derived chunks from `.derive()`, `select()`, or `computed()`).
  *
  * Prefer this over `useChunk` when you only need to read — it makes
@@ -12,16 +12,16 @@ import type { Chunk, ReadOnlyChunk } from "../../core/core";
  *
  * @example
  * const isAuthenticated = userChunk.derive(u => u !== null);
- * const auth = useChunkValue(isAuthenticated); // ✅ no type error
+ * const auth = useChunkValue(isAuthenticated);
  *
  * @example
- * const total = computed(() => price.get() * qty.get());
- * const value = useChunkValue(total); // ✅ no type error
+ * const total = computed(() => price.value * qty.value);
+ * const value = useChunkValue(total);
  */
 export function useChunkValue<T, S = T>(
   chunk: Chunk<T> | ReadOnlyChunk<T>,
   selector?: (value: T) => S
-): Readonly<Ref<S>> {
-  const [value] = useChunk(chunk, selector);
+): ComputedRef<S> {
+  const { value } = useChunk(chunk, selector);
   return value;
 }

--- a/src/use-vue/composables/use-chunk-value.ts
+++ b/src/use-vue/composables/use-chunk-value.ts
@@ -1,0 +1,27 @@
+import type { Ref } from "vue";
+import { useChunk } from "./use-chunk";
+import type { Chunk, ReadOnlyChunk } from "../../core/core";
+
+/**
+ * Subscribes to a chunk and returns only its current value as a readonly ref.
+ * Accepts both writable `Chunk<T>` and read-only `ReadOnlyChunk<T>`
+ * (e.g. derived chunks from `.derive()`, `select()`, or `computed()`).
+ *
+ * Prefer this over `useChunk` when you only need to read — it makes
+ * the read-only intent explicit and works correctly with derived chunks.
+ *
+ * @example
+ * const isAuthenticated = userChunk.derive(u => u !== null);
+ * const auth = useChunkValue(isAuthenticated); // ✅ no type error
+ *
+ * @example
+ * const total = computed(() => price.get() * qty.get());
+ * const value = useChunkValue(total); // ✅ no type error
+ */
+export function useChunkValue<T, S = T>(
+  chunk: Chunk<T> | ReadOnlyChunk<T>,
+  selector?: (value: T) => S
+): Readonly<Ref<S>> {
+  const [value] = useChunk(chunk, selector);
+  return value;
+}

--- a/src/use-vue/composables/use-chunk.ts
+++ b/src/use-vue/composables/use-chunk.ts
@@ -1,32 +1,60 @@
-import { shallowRef, getCurrentScope, onScopeDispose, type Ref } from "vue";
+import { shallowRef, computed, getCurrentScope, onScopeDispose, type ComputedRef, type WritableComputedRef } from "vue";
 import { select } from "../../core/selector";
 import type { Chunk, ReadOnlyChunk } from "../../core/core";
 
+export interface UseChunkResult<T> {
+  /** Reactive value — read via `.value`, write via `.value = x` (or an updater function). Works directly with `v-model`. */
+  value: WritableComputedRef<T, T | ((currentValue: T) => T)>;
+  /** Reset the chunk to its initial value. */
+  reset: () => void;
+  /** Destroy the chunk, clearing all its subscribers. */
+  destroy: () => void;
+}
+
+export interface UseChunkReadOnlyResult<S> {
+  /** Reactive, read-only value. Assigning to `.value` is a no-op (dev builds warn, matching Vue's own read-only computed refs). */
+  value: ComputedRef<S>;
+  /** Reset the underlying chunk to its initial value. No-op when the chunk itself is read-only. */
+  reset: () => void;
+  /** Destroy the underlying chunk — or, when a selector was used, the internal per-component chunk created for it. */
+  destroy: () => void;
+}
+
 /**
- * Subscribes to a chunk and returns its current value as a reactive ref along
- * with setters, reset, and destroy. Accepts both writable `Chunk<T>` and
- * read-only `ReadOnlyChunk<T>` (e.g. derived chunks from `.derive()` or `select()`).
+ * Subscribes to a writable chunk and returns its value as a writable `computed`,
+ * along with `reset` and `destroy`. Assigning `value.value = x` updates the chunk —
+ * `value` binds directly to `v-model`, no separate setter needed.
+ *
+ * Passing a `selector`, or a read-only `ReadOnlyChunk<T>` (e.g. from `.derive()` or
+ * `select()`), always returns a read-only `value` — prefer `useChunkValue` for those.
  *
  * The subscription is cleaned up automatically when the component (or effect
  * scope) that created it is disposed.
  *
- * For read-only chunks, the returned `set` and `reset` will be no-ops at
- * runtime — prefer `useChunkValue` for derived/read-only chunks.
- *
  * @example
  * const count = chunk(0);
- * const [value, setValue] = useChunk(count);
+ * const { value, reset } = useChunk(count);
+ * value.value++;        // triggers chunk.set
  *
  * @example
- * // Works with derived chunks too
- * const doubled = count.derive(n => n * 2);
- * const [value] = useChunk(doubled);
+ * <input v-model="value" />
+ *
+ * @example
+ * // Read-only when selecting a slice — prefer useChunkValue for this
+ * const user = chunk({ name: 'Alice', age: 30 });
+ * const { value: name } = useChunk(user, u => u.name);
  */
+export function useChunk<T>(chunk: Chunk<T>): UseChunkResult<T>;
 export function useChunk<T, S = T>(
   chunk: Chunk<T> | ReadOnlyChunk<T>,
   selector?: (value: T) => S
-) {
+): UseChunkReadOnlyResult<S>;
+export function useChunk<T, S = T>(
+  chunk: Chunk<T> | ReadOnlyChunk<T>,
+  selector?: (value: T) => S
+): UseChunkResult<T> | UseChunkReadOnlyResult<S> {
   const selectedChunk = selector ? select(chunk as Chunk<T>, selector) : chunk;
+  const isWritable = !selector && 'set' in chunk;
 
   const state = shallowRef<S>(selectedChunk.get() as S);
 
@@ -35,14 +63,26 @@ export function useChunk<T, S = T>(
   });
 
   if (getCurrentScope()) {
-    onScopeDispose(() => unsubscribe());
+    onScopeDispose(() => {
+      unsubscribe();
+      // The selected chunk is an internal derived chunk owned by this
+      // composable — destroy() unsubscribes it from the source chunk too.
+      // Without this, every mount/unmount with a selector leaks a
+      // subscription on the source chunk.
+      if (selector) {
+        selectedChunk.destroy();
+      }
+    });
   }
 
-  const set = (valueOrUpdater: T | ((currentValue: T) => T)) => {
-    if ('set' in chunk) {
-      (chunk as Chunk<T>).set(valueOrUpdater);
-    }
-  };
+  const value = isWritable
+    ? computed({
+      get: () => state.value,
+      set: (valueOrUpdater: T | ((currentValue: T) => T)) => {
+        (chunk as Chunk<T>).set(valueOrUpdater);
+      },
+    })
+    : computed(() => state.value);
 
   const reset = () => {
     if ('reset' in chunk) {
@@ -51,8 +91,8 @@ export function useChunk<T, S = T>(
   };
 
   const destroy = () => {
-    chunk.destroy();
+    selectedChunk.destroy();
   };
 
-  return [state as Readonly<Ref<S>>, set, reset, destroy] as const;
+  return { value, reset, destroy } as UseChunkResult<T> | UseChunkReadOnlyResult<S>;
 }

--- a/src/use-vue/composables/use-chunk.ts
+++ b/src/use-vue/composables/use-chunk.ts
@@ -1,0 +1,58 @@
+import { shallowRef, getCurrentScope, onScopeDispose, type Ref } from "vue";
+import { select } from "../../core/selector";
+import type { Chunk, ReadOnlyChunk } from "../../core/core";
+
+/**
+ * Subscribes to a chunk and returns its current value as a reactive ref along
+ * with setters, reset, and destroy. Accepts both writable `Chunk<T>` and
+ * read-only `ReadOnlyChunk<T>` (e.g. derived chunks from `.derive()` or `select()`).
+ *
+ * The subscription is cleaned up automatically when the component (or effect
+ * scope) that created it is disposed.
+ *
+ * For read-only chunks, the returned `set` and `reset` will be no-ops at
+ * runtime — prefer `useChunkValue` for derived/read-only chunks.
+ *
+ * @example
+ * const count = chunk(0);
+ * const [value, setValue] = useChunk(count);
+ *
+ * @example
+ * // Works with derived chunks too
+ * const doubled = count.derive(n => n * 2);
+ * const [value] = useChunk(doubled);
+ */
+export function useChunk<T, S = T>(
+  chunk: Chunk<T> | ReadOnlyChunk<T>,
+  selector?: (value: T) => S
+) {
+  const selectedChunk = selector ? select(chunk as Chunk<T>, selector) : chunk;
+
+  const state = shallowRef<S>(selectedChunk.get() as S);
+
+  const unsubscribe = selectedChunk.subscribe((newValue) => {
+    state.value = newValue as S;
+  });
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => unsubscribe());
+  }
+
+  const set = (valueOrUpdater: T | ((currentValue: T) => T)) => {
+    if ('set' in chunk) {
+      (chunk as Chunk<T>).set(valueOrUpdater);
+    }
+  };
+
+  const reset = () => {
+    if ('reset' in chunk) {
+      (chunk as Chunk<T>).reset();
+    }
+  };
+
+  const destroy = () => {
+    chunk.destroy();
+  };
+
+  return [state as Readonly<Ref<S>>, set, reset, destroy] as const;
+}

--- a/src/use-vue/composables/use-infinite-async-chunk.ts
+++ b/src/use-vue/composables/use-infinite-async-chunk.ts
@@ -1,0 +1,174 @@
+import {
+  ref,
+  computed,
+  watch,
+  watchEffect,
+  getCurrentScope,
+  onScopeDispose,
+  type Ref,
+  type ComputedRef,
+  type MaybeRefOrGetter,
+} from "vue";
+import { useAsyncChunk, UseAsyncChunkOptions, UseAsyncChunkResultWithParamsAndPagination } from './use-async-chunk';
+import { InfiniteAsyncChunk } from '../../query/infinite-async-chunk';
+import type { PaginationState } from '../../query/async-chunk';
+
+export interface UseInfiniteAsyncChunkOptions<T, E extends Error, P extends Record<string, any>>
+  extends Omit<UseAsyncChunkOptions<T[], E, P>, 'params'> {
+  /** Reactive parameters — page and pageSize are managed automatically. Re-fetches from page 1 when these change. */
+  params?: MaybeRefOrGetter<Omit<Partial<P>, 'page' | 'pageSize'> | undefined>;
+  /** Automatically load next page when sentinel enters viewport (default: true) */
+  autoLoad?: boolean;
+  /** IntersectionObserver threshold — 0.0 to 1.0 (default: 1.0) */
+  threshold?: number;
+}
+
+export interface UseInfiniteAsyncChunkResult<T, E extends Error, P extends Record<string, any>> {
+  data: Readonly<Ref<T[] | null>>;
+  loading: Readonly<Ref<boolean>>;
+  error: Readonly<Ref<E | null>>;
+  lastFetched: Readonly<Ref<number | undefined>>;
+  isPlaceholderData: Readonly<Ref<boolean>>;
+  pagination: Readonly<Ref<PaginationState | undefined>>;
+  /** True when fetching a new page while existing data is already loaded */
+  isFetchingMore: ComputedRef<boolean>;
+  /** True if more pages are available */
+  hasMore: ComputedRef<boolean>;
+  reload: (params?: Partial<P>) => Promise<void>;
+  refresh: (params?: Partial<P>) => Promise<void>;
+  mutate: (mutator: (currentData: T[] | null) => T[]) => void;
+  reset: () => void;
+  nextPage: () => Promise<void>;
+  prevPage: () => Promise<void>;
+  goToPage: (page: number) => Promise<void>;
+  resetPagination: () => Promise<void>;
+  /** Manually trigger loading the next page */
+  loadMore: () => void;
+  /** Bind this to a sentinel element at the bottom of your list via a template ref */
+  observerTarget: Ref<HTMLElement | null>;
+}
+
+/**
+ * Subscribes to an infinite async chunk and wires up automatic infinite scroll.
+ *
+ * Bind `observerTarget` to a sentinel element at the bottom of your list —
+ * the next page loads automatically when it enters the viewport.
+ * Use `loadMore()` for manual triggering.
+ *
+ * @param chunk - An `InfiniteAsyncChunk` instance.
+ * @param options.autoLoad - Auto-load on scroll (default: true).
+ * @param options.threshold - IntersectionObserver threshold 0.0–1.0 (default: 1.0).
+ * @param options.params - Reactive params excluding `page` and `pageSize`. Resets to page 1 and refetches when changed.
+ *
+ * @example
+ * <script setup>
+ * const { data, loading, hasMore, observerTarget, loadMore } = useInfiniteAsyncChunk(postsChunk);
+ * </script>
+ *
+ * <template>
+ *   <Post v-for="post in data" :key="post.id" v-bind="post" />
+ *   <div ref="observerTarget" />
+ * </template>
+ *
+ * @example
+ * // Reactive search — resets to page 1 automatically when searchTerm changes
+ * const { data } = useInfiniteAsyncChunk(companiesChunk, {
+ *   params: () => ({ search: searchTerm.value }),
+ * });
+ */
+export function useInfiniteAsyncChunk<
+  T,
+  E extends Error = Error,
+  P extends Record<string, any> = {}
+>(
+  chunk: InfiniteAsyncChunk<T, E, P>,
+  options: UseInfiniteAsyncChunkOptions<T, E, P> = {}
+): UseInfiniteAsyncChunkResult<T, E, P> {
+  const {
+    params,
+    autoLoad = true,
+    threshold = 1.0,
+    fetchOnMount,
+    enabled,
+    onSuccess,
+    onError,
+  } = options;
+
+  // Pass user params only — never page/pageSize, those are owned by the chunk
+  const result = useAsyncChunk(chunk, {
+    params: params as MaybeRefOrGetter<Partial<P> | undefined>,
+    fetchOnMount,
+    enabled,
+    onSuccess,
+    onError,
+  }) as unknown as UseAsyncChunkResultWithParamsAndPagination<T[], E, P>;
+
+  const { data, loading, pagination, nextPage } = result;
+
+  const hasMore = computed(() => pagination.value?.hasMore ?? false);
+
+  const observerTarget = ref<HTMLElement | null>(null);
+
+  // The observer only reports visibility into a ref — a watchEffect combines
+  // it with loading/hasMore. IntersectionObserver notifies on threshold
+  // crossings only, so acting inside its callback deadlocks when the sentinel
+  // is already visible while the initial page loads: the guard rejects the
+  // one notification and no further crossing ever happens. Tracking
+  // visibility reactively means the effect re-fires when loading settles,
+  // cascading pages until the sentinel leaves the viewport or hasMore is
+  // exhausted.
+  if (autoLoad && typeof window !== 'undefined' && 'IntersectionObserver' in window) {
+    const isIntersecting = ref(false);
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        isIntersecting.value = entries[0].isIntersecting;
+      },
+      { threshold }
+    );
+
+    watch(observerTarget, (el, prevEl) => {
+      if (prevEl) observer.unobserve(prevEl);
+      if (el) {
+        observer.observe(el);
+      } else {
+        isIntersecting.value = false;
+      }
+    });
+
+    watchEffect(() => {
+      if (isIntersecting.value && !loading.value && hasMore.value) {
+        nextPage();
+      }
+    });
+
+    if (getCurrentScope()) {
+      onScopeDispose(() => observer.disconnect());
+    }
+  }
+
+  // Manual trigger — consistent with the observer logic
+  const loadMore = () => {
+    if (!loading.value && hasMore.value) {
+      nextPage();
+    }
+  };
+
+  // isFetchingMore: loading a new page while data already exists and pagination
+  // is past page 1 — distinct from the initial load
+  const isFetchingMore = computed(() =>
+    loading.value &&
+    data.value !== null &&
+    data.value.length > 0 &&
+    (pagination.value?.page ?? 1) > 1
+  );
+
+  return {
+    ...result,
+    mutate: result.mutate as (mutator: (currentData: T[] | null) => T[]) => void,
+    isFetchingMore,
+    hasMore,
+    loadMore,
+    observerTarget,
+  };
+}

--- a/src/use-vue/composables/use-mutation.ts
+++ b/src/use-vue/composables/use-mutation.ts
@@ -1,0 +1,76 @@
+import { shallowReactive, toRefs, getCurrentScope, onScopeDispose, type Ref } from "vue";
+import type { Mutation, MutationResult } from "../../query/mutation";
+
+export interface UseMutationResult<TData, TError extends Error = Error, TVariables = void> {
+  /** Current mutation state */
+  loading: Readonly<Ref<boolean>>;
+  data: Readonly<Ref<TData | null>>;
+  error: Readonly<Ref<TError | null>>;
+  isSuccess: Readonly<Ref<boolean>>;
+  /**
+   * Execute the mutation. Always resolves — never throws.
+   * Safe to fire and forget, or await for local UI control.
+   *
+   * @example
+   * // Fire and forget
+   * mutate({ title: 'Hello' });
+   *
+   * // Await for local control — no try/catch needed
+   * const { data, error } = await mutate({ title: 'Hello' });
+   * if (!error) router.push('/posts');
+   */
+  mutate: TVariables extends void
+  ? () => Promise<MutationResult<TData, TError>>
+  : (variables: TVariables) => Promise<MutationResult<TData, TError>>;
+  /** Reset mutation state back to initial */
+  reset: () => void;
+}
+
+/**
+ * Subscribes to a mutation instance and returns its reactive state with `mutate` and `reset`.
+ *
+ * @param mutation - A `mutation()` instance from `stunk/query`.
+ *
+ * @example
+ * const createPost = mutation(
+ *   async (data: NewPost) => fetchAPI('/posts', { method: 'POST', body: data }),
+ *   { invalidates: [postsChunk] }
+ * );
+ *
+ * // In a component setup
+ * const { mutate, loading, error, isSuccess } = useMutation(createPost);
+ *
+ * const handleSubmit = async (data: NewPost) => {
+ *   const { error } = await mutate(data);
+ *   if (!error) router.push('/posts');
+ * };
+ */
+export function useMutation<TData, TError extends Error = Error, TVariables = void>(
+  mutation: Mutation<TData, TError, TVariables>
+): UseMutationResult<TData, TError, TVariables> {
+  // MutationState always carries every key, so a spread + Object.assign stays in sync
+  const state = shallowReactive({ ...mutation.get() });
+
+  const unsubscribe = mutation.subscribe((newState) => {
+    Object.assign(state, newState);
+  });
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => unsubscribe());
+  }
+
+  const mutate = ((...args: TVariables extends void ? [] : [variables: TVariables]) =>
+    (mutation.mutate as (...a: any[]) => Promise<MutationResult<TData, TError>>)(...args)
+  ) as UseMutationResult<TData, TError, TVariables>['mutate'];
+
+  const { loading, data, error, isSuccess } = toRefs(state);
+
+  return {
+    loading,
+    data,
+    error,
+    isSuccess,
+    mutate,
+    reset: () => mutation.reset(),
+  };
+}

--- a/src/use-vue/index.ts
+++ b/src/use-vue/index.ts
@@ -1,0 +1,8 @@
+export { useChunk } from './composables/use-chunk'
+export { useChunkValue } from './composables/use-chunk-value'
+
+export { useAsyncChunk } from './composables/use-async-chunk'
+export { useInfiniteAsyncChunk } from './composables/use-infinite-async-chunk'
+
+export { useMutation } from './composables/use-mutation';
+export type { UseMutationResult } from './composables/use-mutation';

--- a/src/use-vue/index.ts
+++ b/src/use-vue/index.ts
@@ -1,4 +1,5 @@
 export { useChunk } from './composables/use-chunk'
+export type { UseChunkResult, UseChunkReadOnlyResult } from './composables/use-chunk'
 export { useChunkValue } from './composables/use-chunk-value'
 
 export { useAsyncChunk } from './composables/use-async-chunk'

--- a/tests/build/cross-entry-tracking.test.ts
+++ b/tests/build/cross-entry-tracking.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { computed } from "../../dist/index.js";
+import { asyncChunk } from "../../dist/query/index.js";
+
+// Exercises the compiled dist/ output, not src/ — this bug is a bundling
+// artifact that's invisible when testing against source files directly
+// (vite/vitest resolve every import of core/core.ts to one module instance
+// regardless of which file does the importing). Run `pnpm build` first.
+describe("cross-entry dependency tracking (build artifact integrity)", () => {
+  it("computed() from the root entry tracks a dependency on a chunk created via stunk/query", async () => {
+    const source = asyncChunk(async () => "hello");
+
+    // let the initial fetch resolve
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const derived = computed(() => source.get().data);
+    expect(derived.get()).toBe("hello");
+
+    let received: unknown;
+    derived.subscribe((value) => {
+      received = value;
+    });
+
+    source.mutate(() => "updated");
+
+    expect(derived.get()).toBe("updated");
+    expect(received).toBe("updated");
+  });
+});

--- a/tests/query/infinite-async.test.ts
+++ b/tests/query/infinite-async.test.ts
@@ -469,4 +469,44 @@ describe('infiniteAsyncChunk — cleanup', () => {
     chunk.forceCleanup(); // should not throw
     expect(chunk.get().data).toHaveLength(10);
   });
+
+  it('should accumulate when nextPage is called from a microtask after a page lands', async () => {
+    // Regression: nextPage() resets its accumulate flag after `await fetchData`.
+    // A subscriber reacting to the page landing (e.g. a framework scheduler)
+    // that queues another nextPage() on a microtask runs BEFORE that reset —
+    // the reset then landed mid-flight and the new page replaced the
+    // accumulated data instead of appending.
+    const chunk = infiniteAsyncChunk<Post>(
+      async ({ page, pageSize }) =>
+        createDelayedResponse(createPostPage(page, pageSize, 30), 10),
+      { pageSize: 10 }
+    );
+
+    await chunk.reload();
+
+    // Queue on page-2 COMPLETION — nextPage() bumps pagination.page before
+    // setting loading, and that intermediate notification also reports
+    // { loading: false, page: 2 }, so the length check is what
+    // distinguishes "page 2 landed" from "page 2 requested".
+    let queued = false;
+    const unsubscribe = chunk.subscribe((state) => {
+      if (!state.loading && state.pagination?.page === 2 && (state.data?.length ?? 0) === 20 && !queued) {
+        queued = true;
+        Promise.resolve().then(() => chunk.nextPage());
+      }
+    });
+
+    await chunk.nextPage();
+
+    await vi.waitFor(() => {
+      expect(chunk.get().pagination?.page).toBe(3);
+      expect(chunk.get().loading).toBe(false);
+    });
+
+    expect(chunk.get().data).toHaveLength(30);
+    expect(chunk.get().data?.[0].id).toBe(1);
+    expect(chunk.get().data?.[29].id).toBe(30);
+
+    unsubscribe();
+  });
 });

--- a/tests/react/use-async-chunk-hooks-order.test.tsx
+++ b/tests/react/use-async-chunk-hooks-order.test.tsx
@@ -5,6 +5,7 @@ import {
   asyncChunk,
   AsyncChunk,
   PaginatedAsyncChunk,
+  paginatedAsyncChunk,
 } from "../../src/query/async-chunk";
 import { useAsyncChunk } from "../../src/use-react/hooks/use-async-chunk";
 
@@ -29,14 +30,8 @@ function HookHarness({
 describe("useAsyncChunk hook order stability", () => {
   it("does not throw when rerendering from non-paginated to paginated chunk", () => {
     const nonPaginated = asyncChunk(async () => "ok");
-    const paginated = asyncChunk(
-      async ({
-        page = 1,
-        pageSize = 2,
-      }: {
-        page?: number;
-        pageSize?: number;
-      }) => ({
+    const paginated = paginatedAsyncChunk(
+      async ({ page = 1, pageSize = 2 }: { page?: number; pageSize?: number }) => ({
         data: Array.from({ length: pageSize }, (_, i) => `${page}-${i}`),
         hasMore: false,
         total: 2,
@@ -44,9 +39,7 @@ describe("useAsyncChunk hook order stability", () => {
       { pagination: { pageSize: 2 } },
     ) as PaginatedAsyncChunk<string[], Error>;
 
-    const { rerender, getByTestId } = render(
-      <HookHarness source={nonPaginated} />,
-    );
+    const { rerender, getByTestId } = render(<HookHarness source={nonPaginated} />);
 
     expect(() => {
       rerender(<HookHarness source={paginated} />);
@@ -56,14 +49,8 @@ describe("useAsyncChunk hook order stability", () => {
   });
 
   it("does not throw when rerendering from paginated to non-paginated chunk", () => {
-    const paginated = asyncChunk(
-      async ({
-        page = 1,
-        pageSize = 2,
-      }: {
-        page?: number;
-        pageSize?: number;
-      }) => ({
+    const paginated = paginatedAsyncChunk(
+      async ({ page = 1, pageSize = 2 }: { page?: number; pageSize?: number }) => ({
         data: Array.from({ length: pageSize }, (_, i) => `${page}-${i}`),
         hasMore: false,
         total: 2,
@@ -73,9 +60,7 @@ describe("useAsyncChunk hook order stability", () => {
 
     const nonPaginated = asyncChunk(async () => "ok");
 
-    const { rerender, getByTestId } = render(
-      <HookHarness source={paginated} />,
-    );
+    const { rerender, getByTestId } = render(<HookHarness source={paginated} />);
 
     expect(() => {
       rerender(<HookHarness source={nonPaginated} />);
@@ -93,9 +78,7 @@ describe("useAsyncChunk hook order stability", () => {
       return null;
     }
 
-    const { rerender } = render(
-      <InitOnlyHarness params={{ query: "books" }} />,
-    );
+    const { rerender } = render(<InitOnlyHarness params={{ query: "books" }} />);
 
     await waitFor(() => {
       expect(fetcher).toHaveBeenCalledTimes(1);
@@ -125,9 +108,7 @@ describe("useAsyncChunk hook order stability", () => {
       return null;
     }
 
-    const { rerender } = render(
-      <ChunkSwitchHarness source={chunkA} params={{ query: "alpha" }} />,
-    );
+    const { rerender } = render(<ChunkSwitchHarness source={chunkA} params={{ query: "alpha" }} />);
 
     await waitFor(() => {
       expect(fetcherA).toHaveBeenCalledTimes(1);

--- a/tests/vue/helpers.ts
+++ b/tests/vue/helpers.ts
@@ -1,0 +1,22 @@
+import { createApp, type App } from "vue";
+
+/**
+ * Runs a composable inside a real component `setup()` so lifecycle hooks
+ * (onScopeDispose etc.) behave exactly as they do in an app.
+ */
+export function withSetup<T>(composable: () => T): { result: T; app: App; unmount: () => void } {
+  let result!: T;
+
+  const app = createApp({
+    setup() {
+      result = composable();
+      return () => null;
+    },
+  });
+
+  app.mount(document.createElement("div"));
+
+  return { result, app, unmount: () => app.unmount() };
+}
+
+export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/tests/vue/use-async-chunk.test.ts
+++ b/tests/vue/use-async-chunk.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it, vi } from "vitest";
+import { ref, nextTick, defineComponent, h } from "vue";
+import { render, screen, waitFor } from "@testing-library/vue";
+import { asyncChunk, paginatedAsyncChunk } from "../../src/query/async-chunk";
+import { useAsyncChunk } from "../../src/use-vue/composables/use-async-chunk";
+import { withSetup, delay } from "./helpers";
+
+describe("useAsyncChunk (vue) — basic state", () => {
+  it("should expose loading then data after the initial fetch", async () => {
+    const userChunk = asyncChunk(async () => {
+      await delay(10);
+      return { name: "Alice" };
+    });
+
+    const { result, unmount } = withSetup(() => useAsyncChunk(userChunk));
+
+    expect(result.loading.value).toBe(true);
+    expect(result.data.value).toBe(null);
+
+    await vi.waitFor(() => {
+      expect(result.loading.value).toBe(false);
+      expect(result.data.value).toEqual({ name: "Alice" });
+      expect(result.error.value).toBe(null);
+      expect(result.lastFetched.value).toBeTypeOf("number");
+    });
+
+    unmount();
+  });
+
+  it("should expose the error when the fetch fails", async () => {
+    const failing = asyncChunk(async () => {
+      await delay(5);
+      throw new Error("boom");
+    });
+
+    const { result, unmount } = withSetup(() => useAsyncChunk(failing));
+
+    await vi.waitFor(() => {
+      expect(result.loading.value).toBe(false);
+      expect(result.error.value).toBeInstanceOf(Error);
+      expect(result.error.value?.message).toBe("boom");
+      expect(result.data.value).toBe(null);
+    });
+
+    unmount();
+  });
+
+  it("should call onSuccess with the fetched data", async () => {
+    const onSuccess = vi.fn();
+    const userChunk = asyncChunk(async () => {
+      await delay(5);
+      return "hello";
+    });
+
+    const { unmount } = withSetup(() => useAsyncChunk(userChunk, { onSuccess }));
+
+    await vi.waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith("hello");
+    });
+
+    unmount();
+  });
+
+  it("should call onError with the fetch error", async () => {
+    const onError = vi.fn();
+    const failing = asyncChunk(async () => {
+      await delay(5);
+      throw new Error("nope");
+    });
+
+    const { unmount } = withSetup(() => useAsyncChunk(failing, { onError }));
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError.mock.calls[0][0].message).toBe("nope");
+    });
+
+    unmount();
+  });
+
+  it("should update data via mutate without a network request", async () => {
+    let fetchCount = 0;
+    const userChunk = asyncChunk(async () => {
+      fetchCount++;
+      return "original";
+    });
+
+    const { result, unmount } = withSetup(() => useAsyncChunk(userChunk));
+
+    await vi.waitFor(() => expect(result.data.value).toBe("original"));
+
+    result.mutate(() => "mutated");
+    expect(result.data.value).toBe("mutated");
+    expect(fetchCount).toBe(1);
+
+    unmount();
+  });
+
+  it("should reset back to initial state and refetch", async () => {
+    const userChunk = asyncChunk(async () => {
+      await delay(5);
+      return "fresh";
+    });
+
+    const { result, unmount } = withSetup(() => useAsyncChunk(userChunk));
+
+    await vi.waitFor(() => expect(result.data.value).toBe("fresh"));
+
+    result.mutate(() => "dirty");
+    result.reset();
+
+    await vi.waitFor(() => {
+      expect(result.loading.value).toBe(false);
+      expect(result.data.value).toBe("fresh");
+    });
+
+    unmount();
+  });
+
+  it("should stop syncing after unmount", async () => {
+    const userChunk = asyncChunk(async () => {
+      await delay(5);
+      return "done";
+    });
+
+    const { result, unmount } = withSetup(() => useAsyncChunk(userChunk));
+
+    unmount();
+    await delay(20);
+
+    expect(result.loading.value).toBe(true);
+    expect(result.data.value).toBe(null);
+    expect(userChunk.get().data).toBe("done");
+  });
+});
+
+describe("useAsyncChunk (vue) — fetchOnMount", () => {
+  it("should not refetch when data is already loaded", async () => {
+    let fetchCount = 0;
+    const userChunk = asyncChunk(async () => {
+      fetchCount++;
+      return "cached";
+    });
+
+    await vi.waitFor(() => expect(fetchCount).toBe(1));
+
+    const { result, unmount } = withSetup(() => useAsyncChunk(userChunk));
+
+    await delay(20);
+    expect(fetchCount).toBe(1);
+    expect(result.data.value).toBe("cached");
+
+    unmount();
+  });
+
+  it("should force a refetch with fetchOnMount even when data exists", async () => {
+    let fetchCount = 0;
+    const userChunk = asyncChunk(async () => {
+      fetchCount++;
+      return "cached";
+    });
+
+    await vi.waitFor(() => expect(fetchCount).toBe(1));
+
+    const { unmount } = withSetup(() =>
+      useAsyncChunk(userChunk, { fetchOnMount: true })
+    );
+
+    await vi.waitFor(() => expect(fetchCount).toBe(2));
+
+    unmount();
+  });
+});
+
+describe("useAsyncChunk (vue) — enabled & params", () => {
+  it("should not fetch while enabled is false, then fetch when it flips true", async () => {
+    let fetchCount = 0;
+    const userChunk = asyncChunk(async ({ id }: { id: number }) => {
+      fetchCount++;
+      return `user-${id}`;
+    });
+
+    const enabled = ref(false);
+    const { result, unmount } = withSetup(() =>
+      useAsyncChunk(userChunk, { params: { id: 1 }, enabled })
+    );
+
+    await delay(20);
+    expect(fetchCount).toBe(0);
+    expect(result.data.value).toBe(null);
+
+    enabled.value = true;
+    await nextTick();
+
+    await vi.waitFor(() => {
+      expect(fetchCount).toBe(1);
+      expect(result.data.value).toBe("user-1");
+    });
+
+    unmount();
+  });
+
+  it("should cancel the in-flight request when enabled flips false", async () => {
+    const userChunk = asyncChunk(async ({ id }: { id: number }) => {
+      await delay(50);
+      return `user-${id}`;
+    });
+
+    const enabled = ref(true);
+    const { result, unmount } = withSetup(() =>
+      useAsyncChunk(userChunk, { params: { id: 1 }, enabled })
+    );
+
+    await vi.waitFor(() => expect(result.loading.value).toBe(true));
+
+    enabled.value = false;
+    await nextTick();
+
+    expect(result.loading.value).toBe(false);
+
+    await delay(60);
+    expect(result.data.value).toBe(null);
+
+    unmount();
+  });
+
+  it("should refetch when reactive params change", async () => {
+    let fetchCount = 0;
+    const userChunk = asyncChunk(async ({ id }: { id: number }) => {
+      fetchCount++;
+      return `user-${id}`;
+    });
+
+    const id = ref(1);
+    const { result, unmount } = withSetup(() =>
+      useAsyncChunk(userChunk, { params: () => ({ id: id.value }) })
+    );
+
+    await vi.waitFor(() => expect(result.data.value).toBe("user-1"));
+
+    id.value = 2;
+    await nextTick();
+
+    await vi.waitFor(() => {
+      expect(result.data.value).toBe("user-2");
+      expect(fetchCount).toBe(2);
+    });
+
+    unmount();
+  });
+
+  it("should fetch only once when enabled flips true and params change together", async () => {
+    let fetchCount = 0;
+    const userChunk = asyncChunk(async ({ id }: { id: number }) => {
+      fetchCount++;
+      return `user-${id}`;
+    });
+
+    const enabled = ref(false);
+    const id = ref(1);
+    const { result, unmount } = withSetup(() =>
+      useAsyncChunk(userChunk, { params: () => ({ id: id.value }), enabled })
+    );
+
+    await delay(20);
+    expect(fetchCount).toBe(0);
+
+    // Both change in the same tick — must produce exactly one fetch
+    enabled.value = true;
+    id.value = 2;
+    await nextTick();
+
+    await vi.waitFor(() => expect(result.data.value).toBe("user-2"));
+    await delay(20);
+    expect(fetchCount).toBe(1);
+
+    unmount();
+  });
+
+  it("should expose setParams and clearParams for param chunks", async () => {
+    const userChunk = asyncChunk(async ({ id }: { id: number }) => `user-${id}`);
+
+    const { result, unmount } = withSetup(() => useAsyncChunk(userChunk));
+    const withParams = result as typeof result & {
+      setParams: (params: { id: number | null }) => void;
+      clearParams: () => void;
+    };
+
+    expect(typeof withParams.setParams).toBe("function");
+    expect(typeof withParams.clearParams).toBe("function");
+
+    withParams.setParams({ id: 3 });
+    await vi.waitFor(() => expect(result.data.value).toBe("user-3"));
+
+    unmount();
+  });
+});
+
+describe("useAsyncChunk (vue) — pagination", () => {
+  it("should expose pagination state and advance pages", async () => {
+    const pages = paginatedAsyncChunk(
+      async ({ page }: { page: number; pageSize: number }) => ({
+        data: [`page-${page}`],
+        hasMore: true,
+      }),
+      { pagination: { pageSize: 10, mode: "replace" } }
+    );
+
+    const { result, unmount } = withSetup(() => useAsyncChunk(pages));
+    const paginated = result as typeof result & {
+      pagination: { value?: { page: number } };
+      nextPage: () => Promise<void>;
+    };
+
+    await vi.waitFor(() => {
+      expect(result.data.value).toEqual(["page-1"]);
+      expect(paginated.pagination.value?.page).toBe(1);
+    });
+
+    await paginated.nextPage();
+
+    await vi.waitFor(() => {
+      expect(result.data.value).toEqual(["page-2"]);
+      expect(paginated.pagination.value?.page).toBe(2);
+    });
+
+    unmount();
+  });
+});
+
+describe("useAsyncChunk (vue) — scoped resolution", () => {
+  const TestConsumer = defineComponent({
+    props: {
+      chunk: { type: Object, required: true },
+      label: { type: String, required: true },
+    },
+    setup(props) {
+      const { data, pagination, nextPage } = useAsyncChunk(props.chunk as any) as any;
+      return () =>
+        h("div", [
+          h("span", { "data-testid": `${props.label}-page` }, String(pagination?.value?.page ?? "n/a")),
+          h("span", { "data-testid": `${props.label}-data` }, JSON.stringify(data.value)),
+          h("button", { "data-testid": `${props.label}-next`, onClick: () => nextPage() }, "next"),
+        ]);
+    },
+  });
+
+  it("should give each component its own instance for a scoped chunk", async () => {
+    const sharedExport = paginatedAsyncChunk(
+      async ({ page }: { page: number; pageSize: number }) => ({
+        data: [`page-${page}`],
+        hasMore: true,
+      }),
+      {
+        pagination: { pageSize: 10, mode: "replace" },
+        scoped: true,
+      } as any
+    );
+
+    render(
+      defineComponent(() => () =>
+        h("div", [
+          h(TestConsumer, { chunk: sharedExport, label: "a" }),
+          h(TestConsumer, { chunk: sharedExport, label: "b" }),
+        ])
+      )
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("a-data").textContent).toContain("page-1");
+      expect(screen.getByTestId("b-data").textContent).toContain("page-1");
+    });
+
+    // Advance only consumer A to page 2
+    screen.getByTestId("a-next").click();
+    await delay(50);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("a-page").textContent).toBe("2");
+      // B must remain on page 1 — independent instance, not shared state
+      expect(screen.getByTestId("b-page").textContent).toBe("1");
+    });
+  });
+
+  it("should share state across components for a non-scoped chunk", async () => {
+    const sharedExport = paginatedAsyncChunk(
+      async ({ page }: { page: number; pageSize: number }) => ({
+        data: [`page-${page}`],
+        hasMore: true,
+      }),
+      { pagination: { pageSize: 10, mode: "replace" } }
+    );
+
+    render(
+      defineComponent(() => () =>
+        h("div", [
+          h(TestConsumer, { chunk: sharedExport, label: "a" }),
+          h(TestConsumer, { chunk: sharedExport, label: "b" }),
+        ])
+      )
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("a-page").textContent).toBe("1");
+      expect(screen.getByTestId("b-page").textContent).toBe("1");
+    });
+
+    screen.getByTestId("a-next").click();
+    await delay(50);
+
+    // Both consumers observe the same underlying chunk — B updates too
+    await waitFor(() => {
+      expect(screen.getByTestId("a-page").textContent).toBe("2");
+      expect(screen.getByTestId("b-page").textContent).toBe("2");
+    });
+  });
+});

--- a/tests/vue/use-async-chunk.test.ts
+++ b/tests/vue/use-async-chunk.test.ts
@@ -162,9 +162,7 @@ describe("useAsyncChunk (vue) — fetchOnMount", () => {
 
     await vi.waitFor(() => expect(fetchCount).toBe(1));
 
-    const { unmount } = withSetup(() =>
-      useAsyncChunk(userChunk, { fetchOnMount: true })
-    );
+    const { unmount } = withSetup(() => useAsyncChunk(userChunk, { fetchOnMount: true }));
 
     await vi.waitFor(() => expect(fetchCount).toBe(2));
 
@@ -182,7 +180,7 @@ describe("useAsyncChunk (vue) — enabled & params", () => {
 
     const enabled = ref(false);
     const { result, unmount } = withSetup(() =>
-      useAsyncChunk(userChunk, { params: { id: 1 }, enabled })
+      useAsyncChunk(userChunk, { params: { id: 1 }, enabled }),
     );
 
     await delay(20);
@@ -208,7 +206,7 @@ describe("useAsyncChunk (vue) — enabled & params", () => {
 
     const enabled = ref(true);
     const { result, unmount } = withSetup(() =>
-      useAsyncChunk(userChunk, { params: { id: 1 }, enabled })
+      useAsyncChunk(userChunk, { params: { id: 1 }, enabled }),
     );
 
     await vi.waitFor(() => expect(result.loading.value).toBe(true));
@@ -233,7 +231,7 @@ describe("useAsyncChunk (vue) — enabled & params", () => {
 
     const id = ref(1);
     const { result, unmount } = withSetup(() =>
-      useAsyncChunk(userChunk, { params: () => ({ id: id.value }) })
+      useAsyncChunk(userChunk, { params: () => ({ id: id.value }) }),
     );
 
     await vi.waitFor(() => expect(result.data.value).toBe("user-1"));
@@ -259,7 +257,7 @@ describe("useAsyncChunk (vue) — enabled & params", () => {
     const enabled = ref(false);
     const id = ref(1);
     const { result, unmount } = withSetup(() =>
-      useAsyncChunk(userChunk, { params: () => ({ id: id.value }), enabled })
+      useAsyncChunk(userChunk, { params: () => ({ id: id.value }), enabled }),
     );
 
     await delay(20);
@@ -303,7 +301,7 @@ describe("useAsyncChunk (vue) — pagination", () => {
         data: [`page-${page}`],
         hasMore: true,
       }),
-      { pagination: { pageSize: 10, mode: "replace" } }
+      { pagination: { pageSize: 10, mode: "replace" } },
     );
 
     const { result, unmount } = withSetup(() => useAsyncChunk(pages));
@@ -338,7 +336,11 @@ describe("useAsyncChunk (vue) — scoped resolution", () => {
       const { data, pagination, nextPage } = useAsyncChunk(props.chunk as any) as any;
       return () =>
         h("div", [
-          h("span", { "data-testid": `${props.label}-page` }, String(pagination?.value?.page ?? "n/a")),
+          h(
+            "span",
+            { "data-testid": `${props.label}-page` },
+            String(pagination?.value?.page ?? "n/a"),
+          ),
           h("span", { "data-testid": `${props.label}-data` }, JSON.stringify(data.value)),
           h("button", { "data-testid": `${props.label}-next`, onClick: () => nextPage() }, "next"),
         ]);
@@ -354,16 +356,17 @@ describe("useAsyncChunk (vue) — scoped resolution", () => {
       {
         pagination: { pageSize: 10, mode: "replace" },
         scoped: true,
-      } as any
+      } as any,
     );
 
     render(
-      defineComponent(() => () =>
-        h("div", [
-          h(TestConsumer, { chunk: sharedExport, label: "a" }),
-          h(TestConsumer, { chunk: sharedExport, label: "b" }),
-        ])
-      )
+      defineComponent(
+        () => () =>
+          h("div", [
+            h(TestConsumer, { chunk: sharedExport, label: "a" }),
+            h(TestConsumer, { chunk: sharedExport, label: "b" }),
+          ]),
+      ),
     );
 
     await waitFor(() => {
@@ -388,16 +391,17 @@ describe("useAsyncChunk (vue) — scoped resolution", () => {
         data: [`page-${page}`],
         hasMore: true,
       }),
-      { pagination: { pageSize: 10, mode: "replace" } }
+      { pagination: { pageSize: 10, mode: "replace" } },
     );
 
     render(
-      defineComponent(() => () =>
-        h("div", [
-          h(TestConsumer, { chunk: sharedExport, label: "a" }),
-          h(TestConsumer, { chunk: sharedExport, label: "b" }),
-        ])
-      )
+      defineComponent(
+        () => () =>
+          h("div", [
+            h(TestConsumer, { chunk: sharedExport, label: "a" }),
+            h(TestConsumer, { chunk: sharedExport, label: "b" }),
+          ]),
+      ),
     );
 
     await waitFor(() => {

--- a/tests/vue/use-chunk-value.test.ts
+++ b/tests/vue/use-chunk-value.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { chunk } from "../../src/core/core";
+import { computed } from "../../src/core/computed";
+import { select } from "../../src/core/selector";
+import { useChunkValue } from "../../src/use-vue/composables/use-chunk-value";
+import { withSetup } from "./helpers";
+
+describe("useChunkValue (vue)", () => {
+  it("should return a ref tracking the chunk value", () => {
+    const count = chunk(1);
+    const { result: value, unmount } = withSetup(() => useChunkValue(count));
+
+    expect(value.value).toBe(1);
+    count.set(2);
+    expect(value.value).toBe(2);
+    unmount();
+  });
+
+  it("should work with derived chunks", () => {
+    const user = chunk({ name: "Alice" });
+    const isAlice = user.derive((u) => u.name === "Alice");
+    const { result: value, unmount } = withSetup(() => useChunkValue(isAlice));
+
+    expect(value.value).toBe(true);
+    user.set({ name: "Bob" });
+    expect(value.value).toBe(false);
+    unmount();
+  });
+
+  it("should work with computed chunks", () => {
+    const price = chunk(10);
+    const qty = chunk(3);
+    const total = computed(() => price.get() * qty.get());
+    const { result: value, unmount } = withSetup(() => useChunkValue(total));
+
+    expect(value.value).toBe(30);
+    qty.set(5);
+    expect(value.value).toBe(50);
+    unmount();
+  });
+
+  it("should work with select()", () => {
+    const user = chunk({ name: "Alice", age: 30 });
+    const age = select(user, (u) => u.age);
+    const { result: value, unmount } = withSetup(() => useChunkValue(age));
+
+    expect(value.value).toBe(30);
+    user.set({ name: "Alice", age: 31 });
+    expect(value.value).toBe(31);
+    unmount();
+  });
+
+  it("should apply a selector directly", () => {
+    const user = chunk({ name: "Alice", age: 30 });
+    const { result: name, unmount } = withSetup(() => useChunkValue(user, (u) => u.name));
+
+    expect(name.value).toBe("Alice");
+    user.set({ name: "Bob", age: 30 });
+    expect(name.value).toBe("Bob");
+    unmount();
+  });
+
+  it("should stop tracking after unmount", () => {
+    const count = chunk(0);
+    const { result: value, unmount } = withSetup(() => useChunkValue(count));
+
+    unmount();
+    count.set(42);
+    expect(value.value).toBe(0);
+  });
+});

--- a/tests/vue/use-chunk.test.ts
+++ b/tests/vue/use-chunk.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { chunk } from "../../src/core/core";
+import { select } from "../../src/core/selector";
+import { useChunk } from "../../src/use-vue/composables/use-chunk";
+import { withSetup } from "./helpers";
+
+describe("useChunk (vue)", () => {
+  it("should return the current chunk value as a ref", () => {
+    const count = chunk(5);
+    const { result, unmount } = withSetup(() => useChunk(count));
+    const [value] = result;
+
+    expect(value.value).toBe(5);
+    unmount();
+  });
+
+  it("should update the ref when the chunk changes externally", () => {
+    const count = chunk(0);
+    const { result, unmount } = withSetup(() => useChunk(count));
+    const [value] = result;
+
+    count.set(10);
+    expect(value.value).toBe(10);
+    unmount();
+  });
+
+  it("should update the chunk via the returned setter", () => {
+    const count = chunk(0);
+    const { result, unmount } = withSetup(() => useChunk(count));
+    const [value, setValue] = result;
+
+    setValue(7);
+    expect(count.get()).toBe(7);
+    expect(value.value).toBe(7);
+    unmount();
+  });
+
+  it("should support updater functions in the setter", () => {
+    const count = chunk(1);
+    const { result, unmount } = withSetup(() => useChunk(count));
+    const [value, setValue] = result;
+
+    setValue((current) => current + 4);
+    expect(value.value).toBe(5);
+    unmount();
+  });
+
+  it("should reset the chunk to its initial value", () => {
+    const count = chunk(3);
+    const { result, unmount } = withSetup(() => useChunk(count));
+    const [value, setValue, reset] = result;
+
+    setValue(99);
+    reset();
+    expect(value.value).toBe(3);
+    expect(count.get()).toBe(3);
+    unmount();
+  });
+
+  it("should apply a selector and track only the selected slice", () => {
+    const user = chunk({ name: "Alice", age: 30 });
+    const { result, unmount } = withSetup(() => useChunk(user, (u) => u.name));
+    const [name] = result;
+
+    expect(name.value).toBe("Alice");
+
+    user.set({ name: "Alice", age: 31 });
+    expect(name.value).toBe("Alice");
+
+    user.set({ name: "Bob", age: 31 });
+    expect(name.value).toBe("Bob");
+    unmount();
+  });
+
+  it("should treat set and reset as no-ops for read-only selected chunks", () => {
+    const count = chunk(2);
+    const doubled = select(count, (n) => n * 2);
+    const { result, unmount } = withSetup(() => useChunk(doubled));
+    const [value, setValue, reset] = result;
+
+    expect(value.value).toBe(4);
+
+    setValue(100);
+    expect(value.value).toBe(4);
+
+    reset();
+    expect(value.value).toBe(4);
+    unmount();
+  });
+
+  it("should track derived chunks reactively", () => {
+    const count = chunk(2);
+    const doubled = count.derive((n) => n * 2);
+    const { result, unmount } = withSetup(() => useChunk(doubled));
+    const [value] = result;
+
+    count.set(5);
+    expect(value.value).toBe(10);
+    unmount();
+  });
+
+  it("should unsubscribe when the component unmounts", () => {
+    const count = chunk(0);
+    const { result, unmount } = withSetup(() => useChunk(count));
+    const [value] = result;
+
+    unmount();
+    count.set(50);
+    expect(value.value).toBe(0);
+  });
+
+  it("should destroy the chunk via the returned destroy", () => {
+    const count = chunk(1);
+    const { result, unmount } = withSetup(() => useChunk(count));
+    const [, setValue, , destroy] = result;
+
+    setValue(9);
+    destroy();
+    expect(count.get()).toBe(1);
+    unmount();
+  });
+});

--- a/tests/vue/use-chunk.test.ts
+++ b/tests/vue/use-chunk.test.ts
@@ -1,58 +1,53 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { chunk } from "../../src/core/core";
 import { select } from "../../src/core/selector";
 import { useChunk } from "../../src/use-vue/composables/use-chunk";
 import { withSetup } from "./helpers";
 
 describe("useChunk (vue)", () => {
-  it("should return the current chunk value as a ref", () => {
+  it("should return the current chunk value as a computed", () => {
     const count = chunk(5);
     const { result, unmount } = withSetup(() => useChunk(count));
-    const [value] = result;
 
-    expect(value.value).toBe(5);
+    expect(result.value.value).toBe(5);
     unmount();
   });
 
-  it("should update the ref when the chunk changes externally", () => {
+  it("should update the computed when the chunk changes externally", () => {
     const count = chunk(0);
     const { result, unmount } = withSetup(() => useChunk(count));
-    const [value] = result;
 
     count.set(10);
-    expect(value.value).toBe(10);
+    expect(result.value.value).toBe(10);
     unmount();
   });
 
-  it("should update the chunk via the returned setter", () => {
+  it("should update the chunk by assigning to value.value", () => {
     const count = chunk(0);
     const { result, unmount } = withSetup(() => useChunk(count));
-    const [value, setValue] = result;
 
-    setValue(7);
+    result.value.value = 7;
     expect(count.get()).toBe(7);
-    expect(value.value).toBe(7);
+    expect(result.value.value).toBe(7);
     unmount();
   });
 
-  it("should support updater functions in the setter", () => {
+  it("should support updater functions when assigning to value.value", () => {
     const count = chunk(1);
     const { result, unmount } = withSetup(() => useChunk(count));
-    const [value, setValue] = result;
 
-    setValue((current) => current + 4);
-    expect(value.value).toBe(5);
+    result.value.value = (current) => current + 4;
+    expect(result.value.value).toBe(5);
     unmount();
   });
 
   it("should reset the chunk to its initial value", () => {
     const count = chunk(3);
     const { result, unmount } = withSetup(() => useChunk(count));
-    const [value, setValue, reset] = result;
 
-    setValue(99);
-    reset();
-    expect(value.value).toBe(3);
+    result.value.value = 99;
+    result.reset();
+    expect(result.value.value).toBe(3);
     expect(count.get()).toBe(3);
     unmount();
   });
@@ -60,31 +55,43 @@ describe("useChunk (vue)", () => {
   it("should apply a selector and track only the selected slice", () => {
     const user = chunk({ name: "Alice", age: 30 });
     const { result, unmount } = withSetup(() => useChunk(user, (u) => u.name));
-    const [name] = result;
 
-    expect(name.value).toBe("Alice");
+    expect(result.value.value).toBe("Alice");
 
     user.set({ name: "Alice", age: 31 });
-    expect(name.value).toBe("Alice");
+    expect(result.value.value).toBe("Alice");
 
     user.set({ name: "Bob", age: 31 });
-    expect(name.value).toBe("Bob");
+    expect(result.value.value).toBe("Bob");
     unmount();
   });
 
-  it("should treat set and reset as no-ops for read-only selected chunks", () => {
+  it("should be read-only for read-only selected chunks — writes are a no-op", () => {
     const count = chunk(2);
     const doubled = select(count, (n) => n * 2);
     const { result, unmount } = withSetup(() => useChunk(doubled));
-    const [value, setValue, reset] = result;
 
-    expect(value.value).toBe(4);
+    expect(result.value.value).toBe(4);
 
-    setValue(100);
-    expect(value.value).toBe(4);
+    // value is a plain ComputedRef here (a type error in real usage) —
+    // assignment is a dev-mode no-op (Vue warns), matching a genuinely
+    // read-only chunk.
+    (result.value as { value: number }).value = 100;
+    expect(result.value.value).toBe(4);
 
-    reset();
-    expect(value.value).toBe(4);
+    result.reset();
+    expect(result.value.value).toBe(4);
+    unmount();
+  });
+
+  it("should be read-only when a selector is used, even on a writable source chunk", () => {
+    const user = chunk({ name: "Alice", age: 30 });
+    const { result, unmount } = withSetup(() => useChunk(user, (u) => u.name));
+
+    // selecting always returns a read-only computed (a type error in real usage)
+    (result.value as { value: string }).value = "Mallory";
+    expect(result.value.value).toBe("Alice");
+    expect(user.get()).toEqual({ name: "Alice", age: 30 });
     unmount();
   });
 
@@ -92,30 +99,72 @@ describe("useChunk (vue)", () => {
     const count = chunk(2);
     const doubled = count.derive((n) => n * 2);
     const { result, unmount } = withSetup(() => useChunk(doubled));
-    const [value] = result;
 
     count.set(5);
-    expect(value.value).toBe(10);
+    expect(result.value.value).toBe(10);
     unmount();
   });
 
   it("should unsubscribe when the component unmounts", () => {
     const count = chunk(0);
     const { result, unmount } = withSetup(() => useChunk(count));
-    const [value] = result;
 
     unmount();
     count.set(50);
-    expect(value.value).toBe(0);
+    expect(result.value.value).toBe(0);
+  });
+
+  it("should not leak the selector's internal subscription to the source chunk after unmount", () => {
+    const user = chunk({ name: "Alice", age: 30 });
+    const originalSubscribe = user.subscribe.bind(user);
+    const capturedUnsubscribes: ReturnType<typeof vi.fn>[] = [];
+
+    user.subscribe = ((callback: (value: { name: string; age: number }) => void) => {
+      const unsubscribe = originalSubscribe(callback);
+      const spy = vi.fn(unsubscribe);
+      capturedUnsubscribes.push(spy);
+      return spy;
+    }) as typeof user.subscribe;
+
+    const { unmount } = withSetup(() => useChunk(user, (u) => u.name));
+
+    // select() registers exactly one internal subscription on the source chunk
+    expect(capturedUnsubscribes).toHaveLength(1);
+    expect(capturedUnsubscribes[0]).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(capturedUnsubscribes[0]).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not destroy the shared source chunk when destroy is called on a selector-based useChunk", () => {
+    const user = chunk({ name: "Alice", age: 30 });
+    const { result, unmount } = withSetup(() => useChunk(user, (u) => u.name));
+
+    // Mutate before destroy — a source-destroying bug resets this back to
+    // the initial value, which a same-as-initial assertion would miss.
+    user.set({ name: "Bob", age: 31 });
+    result.destroy();
+
+    // Only the internal per-component derived chunk should be torn down —
+    // a shared source chunk must survive, untouched, for other consumers.
+    expect(user.get()).toEqual({ name: "Bob", age: 31 });
+
+    const listener = vi.fn();
+    const unsubscribeListener = user.subscribe(listener);
+    user.set({ name: "Carol", age: 40 });
+    expect(listener).toHaveBeenCalledWith({ name: "Carol", age: 40 });
+    unsubscribeListener();
+
+    unmount();
   });
 
   it("should destroy the chunk via the returned destroy", () => {
     const count = chunk(1);
     const { result, unmount } = withSetup(() => useChunk(count));
-    const [, setValue, , destroy] = result;
 
-    setValue(9);
-    destroy();
+    result.value.value = 9;
+    result.destroy();
     expect(count.get()).toBe(1);
     unmount();
   });

--- a/tests/vue/use-infinite-async-chunk.test.ts
+++ b/tests/vue/use-infinite-async-chunk.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import { infiniteAsyncChunk } from "../../src/query/infinite-async-chunk";
+import { useInfiniteAsyncChunk } from "../../src/use-vue/composables/use-infinite-async-chunk";
+import { withSetup, delay } from "./helpers";
+
+type IntersectionCallback = (entries: { isIntersecting: boolean }[]) => void;
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  callback: IntersectionCallback;
+  observed = new Set<Element>();
+  disconnected = false;
+
+  constructor(callback: IntersectionCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(el: Element) {
+    this.observed.add(el);
+  }
+
+  unobserve(el: Element) {
+    this.observed.delete(el);
+  }
+
+  disconnect() {
+    this.observed.clear();
+    this.disconnected = true;
+  }
+
+  trigger(isIntersecting: boolean) {
+    this.callback([{ isIntersecting }]);
+  }
+}
+
+function createPagesChunk(totalPages = 3, fetchDelay = 0) {
+  let fetchCount = 0;
+  const chunk = infiniteAsyncChunk(
+    async ({ page = 1 }: { page?: number; pageSize: number }) => {
+      fetchCount++;
+      if (fetchDelay) await delay(fetchDelay);
+      return { data: [`item-${page}`], hasMore: page < totalPages };
+    },
+    { pageSize: 10 }
+  );
+  return { chunk, getFetchCount: () => fetchCount };
+}
+
+describe("useInfiniteAsyncChunk (vue)", () => {
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should load page 1 on mount and accumulate pages via loadMore", async () => {
+    const { chunk } = createPagesChunk();
+    const { result, unmount } = withSetup(() => useInfiniteAsyncChunk(chunk));
+
+    await vi.waitFor(() => {
+      expect(result.data.value).toEqual(["item-1"]);
+      expect(result.hasMore.value).toBe(true);
+    });
+
+    result.loadMore();
+    await vi.waitFor(() => {
+      expect(result.data.value).toEqual(["item-1", "item-2"]);
+      expect(result.pagination.value?.page).toBe(2);
+    });
+
+    result.loadMore();
+    await vi.waitFor(() => {
+      expect(result.data.value).toEqual(["item-1", "item-2", "item-3"]);
+      expect(result.hasMore.value).toBe(false);
+    });
+
+    unmount();
+  });
+
+  it("should ignore loadMore when there are no more pages", async () => {
+    const { chunk, getFetchCount } = createPagesChunk(1);
+    const { result, unmount } = withSetup(() => useInfiniteAsyncChunk(chunk));
+
+    await vi.waitFor(() => {
+      expect(result.data.value).toEqual(["item-1"]);
+      expect(result.hasMore.value).toBe(false);
+    });
+
+    result.loadMore();
+    await delay(20);
+
+    expect(getFetchCount()).toBe(1);
+    expect(result.data.value).toEqual(["item-1"]);
+    unmount();
+  });
+
+  it("should ignore loadMore while a page is already loading", async () => {
+    const { chunk, getFetchCount } = createPagesChunk(5, 20);
+    const { result, unmount } = withSetup(() => useInfiniteAsyncChunk(chunk));
+
+    await vi.waitFor(() => expect(result.data.value).toEqual(["item-1"]));
+
+    result.loadMore();
+    result.loadMore();
+    result.loadMore();
+
+    await vi.waitFor(() => expect(result.data.value).toEqual(["item-1", "item-2"]));
+    await delay(30);
+
+    expect(getFetchCount()).toBe(2);
+    unmount();
+  });
+
+  it("should report isFetchingMore only while fetching a subsequent page", async () => {
+    const { chunk } = createPagesChunk(3, 20);
+    const { result, unmount } = withSetup(() => useInfiniteAsyncChunk(chunk));
+
+    // Initial load — loading, but not "fetching more"
+    expect(result.isFetchingMore.value).toBe(false);
+    await vi.waitFor(() => expect(result.data.value).toEqual(["item-1"]));
+
+    result.loadMore();
+    await vi.waitFor(() => expect(result.isFetchingMore.value).toBe(true));
+
+    await vi.waitFor(() => {
+      expect(result.data.value).toEqual(["item-1", "item-2"]);
+      expect(result.isFetchingMore.value).toBe(false);
+    });
+
+    unmount();
+  });
+
+  it("should load the next page when the sentinel intersects and stop when it leaves", async () => {
+    // Slow fetches so each page load is an unambiguous landmark — the
+    // reactive cascade would outrun waitFor's poll interval otherwise
+    const { chunk, getFetchCount } = createPagesChunk(5, 100);
+    const { result, unmount } = withSetup(() => useInfiniteAsyncChunk(chunk));
+
+    await vi.waitFor(() => expect(result.data.value).toEqual(["item-1"]));
+
+    const observer = MockIntersectionObserver.instances[0];
+    expect(observer).toBeDefined();
+
+    const sentinel = document.createElement("div");
+    result.observerTarget.value = sentinel;
+    await nextTick();
+
+    expect(observer.observed.has(sentinel)).toBe(true);
+
+    observer.trigger(true);
+    await vi.waitFor(() => expect(result.loading.value).toBe(true));
+
+    // New content pushes the sentinel out of the viewport while page 2 is
+    // still in flight — the cascade must stop after it lands
+    observer.trigger(false);
+
+    await vi.waitFor(() => expect(result.data.value).toEqual(["item-1", "item-2"]));
+    await delay(150);
+    expect(result.data.value).toEqual(["item-1", "item-2"]);
+    expect(getFetchCount()).toBe(2);
+
+    unmount();
+  });
+
+  it("should auto-load once loading settles when the sentinel was already visible during the initial load", async () => {
+    const { chunk, getFetchCount } = createPagesChunk(2, 10);
+    const { result, unmount } = withSetup(() => useInfiniteAsyncChunk(chunk));
+
+    const observer = MockIntersectionObserver.instances[0];
+    const sentinel = document.createElement("div");
+    result.observerTarget.value = sentinel;
+    await nextTick();
+
+    // The sentinel is visible while page 1 is still loading. A real
+    // IntersectionObserver notifies exactly once here and never again —
+    // no crossing happens if the sentinel stays in the viewport.
+    observer.trigger(true);
+    expect(result.loading.value).toBe(true);
+
+    // Once loading settles, page 2 must load without another notification.
+    await vi.waitFor(() =>
+      expect(result.data.value).toEqual(["item-1", "item-2"])
+    );
+    expect(result.hasMore.value).toBe(false);
+    expect(getFetchCount()).toBe(2);
+
+    unmount();
+  });
+
+  it("should not load when the sentinel intersects but hasMore is false", async () => {
+    const { chunk, getFetchCount } = createPagesChunk(1);
+    const { result, unmount } = withSetup(() => useInfiniteAsyncChunk(chunk));
+
+    await vi.waitFor(() => expect(result.hasMore.value).toBe(false));
+
+    const observer = MockIntersectionObserver.instances[0];
+    const sentinel = document.createElement("div");
+    result.observerTarget.value = sentinel;
+    await nextTick();
+
+    observer.trigger(true);
+    await delay(20);
+
+    expect(getFetchCount()).toBe(1);
+    unmount();
+  });
+
+  it("should not create an observer when autoLoad is false", async () => {
+    const { chunk } = createPagesChunk();
+    const { result, unmount } = withSetup(() =>
+      useInfiniteAsyncChunk(chunk, { autoLoad: false })
+    );
+
+    await vi.waitFor(() => expect(result.data.value).toEqual(["item-1"]));
+
+    expect(MockIntersectionObserver.instances).toHaveLength(0);
+    unmount();
+  });
+
+  it("should disconnect the observer on unmount", async () => {
+    const { chunk } = createPagesChunk();
+    const { result, unmount } = withSetup(() => useInfiniteAsyncChunk(chunk));
+
+    await vi.waitFor(() => expect(result.data.value).toEqual(["item-1"]));
+
+    const observer = MockIntersectionObserver.instances[0];
+    unmount();
+
+    expect(observer.disconnected).toBe(true);
+  });
+});

--- a/tests/vue/use-mutation.test.ts
+++ b/tests/vue/use-mutation.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { mutation } from "../../src/query/mutation";
+import { asyncChunk } from "../../src/query/async-chunk";
+import { useMutation } from "../../src/use-vue/composables/use-mutation";
+import { withSetup, delay } from "./helpers";
+
+describe("useMutation (vue)", () => {
+  it("should start in the initial state", () => {
+    const createPost = mutation(async (title: string) => ({ id: 1, title }));
+    const { result, unmount } = withSetup(() => useMutation(createPost));
+
+    expect(result.loading.value).toBe(false);
+    expect(result.data.value).toBe(null);
+    expect(result.error.value).toBe(null);
+    expect(result.isSuccess.value).toBe(false);
+    unmount();
+  });
+
+  it("should track loading during the mutation and data on success", async () => {
+    const createPost = mutation(async (title: string) => {
+      await delay(10);
+      return { id: 1, title };
+    });
+
+    const { result, unmount } = withSetup(() => useMutation(createPost));
+
+    const promise = result.mutate("Hello");
+    await vi.waitFor(() => expect(result.loading.value).toBe(true));
+
+    await promise;
+
+    expect(result.loading.value).toBe(false);
+    expect(result.data.value).toEqual({ id: 1, title: "Hello" });
+    expect(result.isSuccess.value).toBe(true);
+    expect(result.error.value).toBe(null);
+    unmount();
+  });
+
+  it("should resolve with { data, error } and never throw on failure", async () => {
+    const failing = mutation(async (_title: string) => {
+      await delay(5);
+      throw new Error("save failed");
+    });
+
+    const { result, unmount } = withSetup(() => useMutation(failing));
+
+    const { data, error } = await result.mutate("Hello");
+
+    expect(data).toBe(null);
+    expect(error).toBeInstanceOf(Error);
+    expect(result.error.value?.message).toBe("save failed");
+    expect(result.isSuccess.value).toBe(false);
+    expect(result.loading.value).toBe(false);
+    unmount();
+  });
+
+  it("should reset state back to initial", async () => {
+    const createPost = mutation(async (title: string) => ({ id: 1, title }));
+    const { result, unmount } = withSetup(() => useMutation(createPost));
+
+    await result.mutate("Hello");
+    expect(result.isSuccess.value).toBe(true);
+
+    result.reset();
+
+    expect(result.data.value).toBe(null);
+    expect(result.error.value).toBe(null);
+    expect(result.isSuccess.value).toBe(false);
+    unmount();
+  });
+
+  it("should reload invalidated chunks after a successful mutation", async () => {
+    let fetchCount = 0;
+    const posts = asyncChunk(async () => {
+      fetchCount++;
+      return ["post-1"];
+    });
+
+    await vi.waitFor(() => expect(fetchCount).toBe(1));
+
+    const createPost = mutation(async (title: string) => ({ id: 1, title }), {
+      invalidates: [posts],
+    });
+
+    const { result, unmount } = withSetup(() => useMutation(createPost));
+
+    await result.mutate("Hello");
+
+    await vi.waitFor(() => expect(fetchCount).toBe(2));
+    unmount();
+  });
+
+  it("should stop syncing after unmount", async () => {
+    const createPost = mutation(async (title: string) => {
+      await delay(10);
+      return { id: 1, title };
+    });
+
+    const { result, unmount } = withSetup(() => useMutation(createPost));
+
+    const promise = createPost.mutate("Hello");
+    unmount();
+    await promise;
+
+    expect(result.data.value).toBe(null);
+    expect(createPost.get().data).toEqual({ id: 1, title: "Hello" });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "declaration": true,
     "paths": {
       "stunk/middleware": ["./src/middleware"],
-      "stunk/react": ["./src/use-react"]
+      "stunk/react": ["./src/use-react"],
+      "stunk/vue": ["./src/use-vue"]
     },
     "typeRoots": ["./node_modules/@types", "./types"],
     "strict": true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -18,13 +18,13 @@ export default defineConfig([
     },
   },
 
-  // Subpath entries — middleware, query, react
+  // Subpath entries — middleware, query, react, vue
   {
     entry: {
       'middleware/index': 'src/middleware/index.ts',
       'use-react/index': 'src/use-react/index.ts',
       'query/index': 'src/query/index.ts',
-      // 'use-vue/index': 'src/use-vue/index.ts',
+      'use-vue/index': 'src/use-vue/index.ts',
     },
     format: ['esm'],
     dts: true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,41 +1,32 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig([
-  // Main bundle — core, utilities, types
-  {
-    entry: ['src/index.ts'],
-    format: ['esm'],
-    dts: true,
-    clean: true,
-    minify: true,
-    sourcemap: false,
-    outDir: 'dist',
-    treeshake: true,
-    splitting: false,
-    target: 'es2020',
-    define: {
-      __DEV__: 'false',
-    },
+export default defineConfig({
+  // A single entry group so every entry point shares the same code-split
+  // chunks — critically core/core.ts, which holds the module-level
+  // dependency-tracking state computed()/select()/batch() rely on. Building
+  // the main entry separately (as two defineConfig groups previously did)
+  // gives it its own inlined copy of core.ts, so a computed() imported from
+  // 'stunk' can never track a dependency read inside a chunk created via
+  // 'stunk/query' (or vue/react) — they're watching two different
+  // activeEffect variables that never see each other.
+  entry: {
+    index: 'src/index.ts',
+    'middleware/index': 'src/middleware/index.ts',
+    'use-react/index': 'src/use-react/index.ts',
+    'query/index': 'src/query/index.ts',
+    'use-vue/index': 'src/use-vue/index.ts',
   },
-
-  // Subpath entries — middleware, query, react, vue
-  {
-    entry: {
-      'middleware/index': 'src/middleware/index.ts',
-      'use-react/index': 'src/use-react/index.ts',
-      'query/index': 'src/query/index.ts',
-      'use-vue/index': 'src/use-vue/index.ts',
-    },
-    format: ['esm'],
-    dts: true,
-    minify: true,
-    sourcemap: false,
-    outDir: 'dist',
-    treeshake: true,
-    target: 'es2020',
-    external: ['react', 'vue'],
-    define: {
-      __DEV__: 'false',
-    },
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  minify: true,
+  sourcemap: false,
+  outDir: 'dist',
+  treeshake: true,
+  splitting: true,
+  target: 'es2020',
+  external: ['react', 'vue'],
+  define: {
+    __DEV__: 'false',
   },
-])
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ import vue from "@vitejs/plugin-vue"
 export default defineConfig({
   plugins: [
     react({ include: /tests\/react\/.+\.(tsx?|jsx?)$/ }),
-    vue({ include: /tests\/vue\/.+\.(vue|ts)$/ }),
+    vue({ include: /tests\/vue\/.+\.vue$/ }),
   ],
   test: {
     environment: "jsdom",


### PR DESCRIPTION
## Summary

Adds a `stunk/vue` subpath with Vue 3 composables mirroring the existing React hooks, plus a couple of core fixes found along the way:

- `useChunk` / `useChunkValue` — subscribe to a chunk; `useChunk` returns `{ value, reset, destroy }` where `value` is a writable `computed()` (assign `.value` directly, works with `v-model`) for writable chunks, and a read-only `computed()` when a selector is used or the source chunk is read-only
- `useAsyncChunk` / `useInfiniteAsyncChunk` — reactive params/enabled via `MaybeRefOrGetter`, pagination, infinite-scroll via `IntersectionObserver`
- `useMutation` — reactive mutation state with `mutate`/`reset`
- `stunk/vue` wired up as its own tsup entry and package.json export

Fixes bundled in:
- `useChunk`'s selector path never destroyed the internal derived chunk on scope dispose, leaking a subscription to the source chunk on every mount/unmount; `destroy()` also always targeted the original passed-in chunk, so a selector-based `useChunk` could wipe a shared source chunk out from under other consumers. Both fixed, with regression tests.
- `paginatedAsyncChunk` fetches are now race-safe for scheduler-driven callers (see `fix(query)` commit).
- Root `stunk` entry and the `stunk/query`/`stunk/react`/`stunk/vue` entries were built as separate tsup config groups and never shared code-split chunks, so they each got their own copy of `core/core.ts`'s module-level dependency tracker. A `computed()` imported from `stunk` could never auto-track a dependency on a chunk created via `stunk/query`. Fixed by building all entries as one group; added `tests/build/cross-entry-tracking.test.ts`, which exercises the compiled `dist/` output specifically since this is a bundling artifact invisible at the source level.

## Test plan

- [x] `pnpm build` succeeds; `dist/index.js` and `dist/query/index.js` now share the same `core.ts` chunk
- [x] Full test suite green (`tests/vue/*`, `tests/build/*`, plus the existing suite) — only pre-existing, unrelated `tests/core/persist.test.ts` failures on Node 25 (passes on Node 20/CI)
- [x] `tsc --noEmit` clean
- [x] Verified end-to-end in a standalone Vue 3 demo app consuming the built package (`file:` dependency) — theme toggle, list/derive/computed reactivity, async fetch with reactive params, infinite scroll, mutation + invalidation, all exercised via a scripted Playwright pass